### PR TITLE
fix out of bounds access

### DIFF
--- a/contracts/libraries/Uint32L8Array.sol
+++ b/contracts/libraries/Uint32L8Array.sol
@@ -48,6 +48,8 @@ library Uint32L8ArrayLib {
             }
         }
 
+        i = i == 8 ? 7 : i;
+
         if (elementIndex != 8) {
             if (i == elementIndex) {
                 array[elementIndex] = 0;


### PR DESCRIPTION
Fixes out of bounds access. The variable `i` searches for the index of the last valid element. When no invalid element is found, i defaults to 8. To fix this, when i is 8 - set it to 7. Tested and works.