### PR TITLE
remove "test" from .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,7 +5,6 @@
 cache
 node_modules
 types
-./test
 deployments/localhost
 .gitignore
 .prettierrc

--- a/.npmignore
+++ b/.npmignore
@@ -4,7 +4,6 @@
 .env.example
 cache
 node_modules
-test
 types
 deployments/localhost
 .gitignore

--- a/.npmignore
+++ b/.npmignore
@@ -5,6 +5,7 @@
 cache
 node_modules
 types
+./test
 deployments/localhost
 .gitignore
 .prettierrc


### PR DESCRIPTION
I needed to access the mock files in order to properly create a test suite for clearing house. But because "test" was included in the .npmignore, all files in the "test" directory were excluded such as OracleMock and RealTokenMock. This PR removes test from the .npmignore to fix this issue.