### PR TITLE
QSP Documentation

### DIFF
--- a/contracts/libraries/Account.sol
+++ b/contracts/libraries/Account.sol
@@ -226,6 +226,8 @@ library Account {
     /// @param account account to deposit balance into
     /// @param collateralId collateral id of the token
     /// @param amount amount of token to deposit or withdraw
+    /// @param protocol set of all constants and token addresses
+    /// @param checkMargin true to check if margin is available else false
     function updateMargin(
         Account.Info storage account,
         uint32 collateralId,
@@ -240,6 +242,7 @@ library Account {
     /// @param account account to remove profit from
     /// @param amount amount of profit(settlement token) to add/remove
     /// @param protocol set of all constants and token addresses
+    /// @param checkMargin true to check if margin is available else false
     function updateProfit(
         Account.Info storage account,
         int256 amount,
@@ -262,6 +265,9 @@ library Account {
     /// @param poolId id of the pool to swap tokens for
     /// @param swapParams parameters for the swap (Includes - amount, sqrtPriceLimit, isNotional, isPartialAllowed)
     /// @param protocol set of all constants and token addresses
+    /// @param checkMargin true to check if margin is available else false
+    /// @return vTokenAmountOut amount of vToken after swap (user receiving then +ve, user paying then -ve)
+    /// @return vQuoteAmountOut amount of vQuote after swap (user receiving then +ve, user paying then -ve)
     function swapToken(
         Account.Info storage account,
         uint32 poolId,
@@ -364,6 +370,8 @@ library Account {
     /// @param account account to liquidate
     /// @param poolId id of the pool to liquidate
     /// @param protocol set of all constants and token addresses
+    /// @return keeperFee amount of liquidation fee paid to keeper
+    /// @return insuranceFundFee amount of liquidation fee paid to insurance fund
     function liquidateTokenPosition(
         Account.Info storage account,
         uint32 poolId,
@@ -582,6 +590,7 @@ library Account {
     /// @param account account to remove profit from
     /// @param amount amount of profit(settlement token) to add/remove
     /// @param protocol set of all constants and token addresses
+    /// @param checkMargin true to check if margin is available else false
     function _updateProfit(
         Account.Info storage account,
         int256 amount,
@@ -602,6 +611,8 @@ library Account {
     /// @param account account to deposit balance into
     /// @param collateralId collateral id of the token
     /// @param amount amount of token to deposit or withdraw
+    /// @param protocol set of all constants and token addresses
+    /// @param checkMargin true to check if margin is available else false
     function _updateMargin(
         Account.Info storage account,
         uint32 collateralId,
@@ -622,6 +633,7 @@ library Account {
     /// @notice updates the vQuote balance for 'account' by 'amount'
     /// @param account pointer to 'account' struct
     /// @param amount amount of balance to update
+    /// @return balanceAdjustments vToken and vQuote balance changes of the account
     function _updateVQuoteBalance(Account.Info storage account, int256 amount)
         internal
         returns (IClearingHouseStructures.BalanceAdjustments memory balanceAdjustments)

--- a/contracts/libraries/PriceMath.sol
+++ b/contracts/libraries/PriceMath.sol
@@ -15,8 +15,8 @@ library PriceMath {
     error IllegalSqrtPrice(uint160 sqrtPriceX96);
 
     /// @notice Computes the square of a sqrtPriceX96 value
-    /// @param sqrtPriceX96: input price in Q128 format
-    /// @return priceX128 : the square root of the input price in Q96 format
+    /// @param sqrtPriceX96: the square root of the input price in Q96 format
+    /// @return priceX128 : input price in Q128 format
     function toPriceX128(uint160 sqrtPriceX96) internal pure returns (uint256 priceX128) {
         if (sqrtPriceX96 < TickMath.MIN_SQRT_RATIO || sqrtPriceX96 >= TickMath.MAX_SQRT_RATIO) {
             revert IllegalSqrtPrice(sqrtPriceX96);

--- a/contracts/libraries/SwapMath.sol
+++ b/contracts/libraries/SwapMath.sol
@@ -212,6 +212,7 @@ library SwapMath {
 
     /// @notice Applies the fees in the amount, based on sign of the amount
     /// @param amount amount to which fees are to be applied
+    /// @param fees fees to be applied
     /// @param includeFeeEnum procedure to apply the fee
     /// @return amountAfterFees amount after applying fees
     function includeFees(

--- a/contracts/libraries/VTokenPosition.sol
+++ b/contracts/libraries/VTokenPosition.sol
@@ -55,6 +55,7 @@ library VTokenPosition {
     /// @param position token position
     /// @param priceX128 price in Q128
     /// @param wrapper pool wrapper corresponding to position
+    /// @return value market value with 6 decimals
     function marketValue(
         VTokenPosition.Info storage position,
         uint256 priceX128,
@@ -98,6 +99,7 @@ library VTokenPosition {
     /// @notice returns the vQuoteIncrease due to unrealized funding payment for the trader position (+ve means receiving and -ve means paying)
     /// @param position token position
     /// @param wrapper pool wrapper corresponding to position
+    /// @return unrealizedFpBill funding to be realized (+ve means receive and -ve means pay)
     function unrealizedFundingPayment(VTokenPosition.Info storage position, IVPoolWrapper wrapper)
         internal
         view

--- a/contracts/libraries/VTokenPositionSet.sol
+++ b/contracts/libraries/VTokenPositionSet.sol
@@ -132,6 +132,7 @@ library VTokenPositionSet {
 
     /// @notice swaps tokens (Long and Short) with input in token amount / vQuote amount
     /// @param set VTokenPositionSet
+    /// @param accountId account identifier, used for emitting event
     /// @param poolId id of the rage trade pool
     /// @param swapParams parameters for swap
     /// @param protocol platform constants
@@ -150,6 +151,7 @@ library VTokenPositionSet {
     /// @notice swaps tokens (Long and Short) with input in token amount
     /// @dev activates inactive vToe
     /// @param set VTokenPositionSet
+    /// @param accountId account identifier, used for emitting event
     /// @param poolId id of the rage trade pool
     /// @param vTokenAmount amount of the token
     /// @param protocol platform constants
@@ -181,6 +183,7 @@ library VTokenPositionSet {
 
     /// @notice swaps tokens (Long and Short) with input in token amount / vQuote amount
     /// @param set VTokenPositionSet
+    /// @param accountId account identifier, used for emitting event
     /// @param poolId id of the rage trade pool
     /// @param swapParams parameters for swap
     /// @param wrapper VPoolWrapper to override the set wrapper
@@ -222,6 +225,7 @@ library VTokenPositionSet {
 
     /// @notice function to liquidate all liquidity positions
     /// @param set VTokenPositionSet
+    /// @param accountId account identifier, used for emitting event
     /// @param protocol platform constants
     /// @return notionalAmountClosed - value of net token position coming out (in notional) of all the ranges closed
     function liquidateLiquidityPositions(
@@ -239,6 +243,7 @@ library VTokenPositionSet {
 
     /// @notice function to liquidate liquidity positions for a particular token
     /// @param set VTokenPositionSet
+    /// @param accountId account identifier, used for emitting event
     /// @param poolId id of the rage trade pool
     /// @param protocol platform constants
     /// @return notionalAmountClosed - value of net token position coming out (in notional) of all the ranges closed
@@ -265,6 +270,7 @@ library VTokenPositionSet {
 
     /// @notice function for liquidity add/remove
     /// @param set VTokenPositionSet
+    /// @param accountId account identifier, used for emitting event
     /// @param poolId id of the rage trade pool
     /// @param liquidityChangeParams includes tickLower, tickUpper, liquidityDelta, limitOrderType
     /// @return vTokenAmountOut amount of tokens that account received (positive) or paid (negative)
@@ -300,6 +306,7 @@ library VTokenPositionSet {
     /// @notice function to remove an eligible limit order
     /// @dev checks whether the current price is on the correct side of the range based on the type of limit order (None, Low, High)
     /// @param set VTokenPositionSet
+    /// @param accountId account identifier, used for emitting event
     /// @param poolId id of the rage trade pool
     /// @param tickLower lower tick index for the range
     /// @param tickUpper upper tick index for the range

--- a/contracts/protocol/tokens/VQuoteDeployer.sol
+++ b/contracts/protocol/tokens/VQuoteDeployer.sol
@@ -9,12 +9,12 @@ import { GoodAddressDeployer } from '../../libraries/GoodAddressDeployer.sol';
 import { VQuote } from '../tokens/VQuote.sol';
 
 abstract contract VQuoteDeployer {
-    function _deployVQuote(uint8 rsettlementTokenecimals) internal returns (IVQuote vQuote) {
+    function _deployVQuote(uint8 rSettlementTokenDecimals) internal returns (IVQuote vQuote) {
         return
             IVQuote(
                 GoodAddressDeployer.deploy(
                     0,
-                    abi.encodePacked(type(VQuote).creationCode, abi.encode(rsettlementTokenecimals)),
+                    abi.encodePacked(type(VQuote).creationCode, abi.encode(rSettlementTokenDecimals)),
                     _isVQuoteAddressGood
                 )
             );

--- a/contracts/utils/TimelockControllerWithMinDelayOverride.sol
+++ b/contracts/utils/TimelockControllerWithMinDelayOverride.sol
@@ -77,7 +77,7 @@ contract TimelockControllerWithMinDelayOverride is TimelockController {
 
     function _getKey(address target, bytes4 selector) internal pure returns (bytes32 c) {
         assembly {
-            // store a in the last 20 bytes and b in the 4 bytes before
+            // store target in the last 20 bytes and selector in the 4 bytes before
             c := xor(target, selector)
         }
     }


### PR DESCRIPTION
1. Missing or incorrect NatSpec parameter comments:
    1. Missing parameters protocol and checkMargin in Account.updateMargin() and Account._updateMargin().
    2. Missing parameter checkMargin in Account.updateProfit() and Account._updateProfit().
    3. Missing return value balanceAdjustments in Account._updateVQuoteBalance().
    4. Missing return value value in VTokenPosition.marketValue().
    5. Missing return value in VTokenPosition.unrealizedFundingPayment().
    6. NatSpec parameter sqrtPriceX96 in PriceMath.toPriceX128() wrongfully states input price in Q128 format, however the format is Q96, not Q128.
    7. Missing parameters checkMargin and return values vTokenAmountOut and vQuoteAmountOut in Account.swapToken().
    8. Missing parameters fixFee and return values keeperFee, insuranceFundFee and accountMarketValue in Account.liquidateLiquidityPositions().
    9. Missing parameters fixFee and return values keeperFee and insuranceFundFee in Account.liquidateTokenPosition().
    10. Missing parameter fees in SwapMath.includeFees().
    11. Missing parameter accountId in VTokenPositionSet.swapToken().
    12. Missing parameter accountId in VTokenPositionSet.liquidateLiquidityPositions().
    13. Missing parameter accountId in VTokenPositionSet.liquidityChange().
    14. Missing parameter accountId in VTokenPositionSet.removeLimitOrder().
2. The following typographical error has been noted:
    1. contracts/protocol/tokens/VQuoteDeployer.sol: rsettlementTokenecimals should be rsettlementToken[d]ecimals.
3. On in the code comment and the implementation on are different. Please correct the code
comment.