### PR TITLE
QSP-13: Use confirmation while transferring governance

### DIFF
--- a/contracts/interfaces/IGovernable.sol
+++ b/contracts/interfaces/IGovernable.sol
@@ -5,9 +5,17 @@ pragma solidity ^0.8.9;
 interface IGovernable {
     function governance() external view returns (address);
 
+    function governancePending() external view returns (address);
+
     function teamMultisig() external view returns (address);
 
-    function transferGovernance(address newGovernance) external;
+    function teamMultisigPending() external view returns (address);
 
-    function transferTeamMultisig(address newTeamMultisig) external;
+    function initiateGovernanceTransfer(address newGovernancePending) external;
+
+    function acceptGovernanceTransfer() external;
+
+    function initiateTeamMultisigTransfer(address newTeamMultisigPending) external;
+
+    function acceptTeamMultisigTransfer() external;
 }

--- a/contracts/interfaces/clearinghouse/IClearingHouseSystemActions.sol
+++ b/contracts/interfaces/clearinghouse/IClearingHouseSystemActions.sol
@@ -20,6 +20,8 @@ interface IClearingHouseSystemActions is IClearingHouseStructures {
     /// @param vQuote address of vQuote
     function initialize(
         address rageTradeFactoryAddress,
+        address initialGovernance,
+        address initialTeamMultisig,
         IERC20 defaultCollateralToken,
         IOracle defaultCollateralTokenOracle,
         IInsuranceFund insuranceFund,

--- a/contracts/protocol/RageTradeFactory.sol
+++ b/contracts/protocol/RageTradeFactory.sol
@@ -77,8 +77,6 @@ contract RageTradeFactory is
                 vQuote
             )
         );
-        clearingHouse.initiateGovernanceTransfer(msg.sender);
-        clearingHouse.initiateTeamMultisigTransfer(msg.sender);
 
         _initializeInsuranceFund(insuranceFund, settlementToken, clearingHouse);
     }

--- a/contracts/protocol/RageTradeFactory.sol
+++ b/contracts/protocol/RageTradeFactory.sol
@@ -77,8 +77,8 @@ contract RageTradeFactory is
                 vQuote
             )
         );
-        clearingHouse.transferGovernance(msg.sender);
-        clearingHouse.transferTeamMultisig(msg.sender);
+        clearingHouse.initiateGovernanceTransfer(msg.sender);
+        clearingHouse.initiateTeamMultisigTransfer(msg.sender);
 
         _initializeInsuranceFund(insuranceFund, settlementToken, clearingHouse);
     }

--- a/contracts/protocol/clearinghouse/ClearingHouse.sol
+++ b/contracts/protocol/clearinghouse/ClearingHouse.sol
@@ -62,6 +62,8 @@ contract ClearingHouse is
 
     function initialize(
         address _rageTradeFactoryAddress,
+        address initialGovernance,
+        address initialTeamMultisig,
         IERC20 _defaultCollateralToken,
         IOracle _defaultCollateralTokenOracle,
         IInsuranceFund _insuranceFund,
@@ -78,7 +80,7 @@ contract ClearingHouse is
             CollateralSettings({ oracle: _defaultCollateralTokenOracle, twapDuration: 60, isAllowedForDeposit: true })
         );
 
-        __Governable_init();
+        __Governable_init(initialGovernance, initialTeamMultisig);
         __Pausable_init_unchained();
     }
 

--- a/contracts/protocol/clearinghouse/ClearingHouseDeployer.sol
+++ b/contracts/protocol/clearinghouse/ClearingHouseDeployer.sol
@@ -38,6 +38,8 @@ abstract contract ClearingHouseDeployer is ProxyAdminDeployer {
                             IClearingHouseSystemActions.initialize,
                             (
                                 address(this), // RageTradeFactory
+                                msg.sender, // initialGovernance
+                                msg.sender, // initialTeamMultisig
                                 params.settlementToken,
                                 params.settlementTokenOracle,
                                 params.insuranceFund,

--- a/contracts/test/Governable.sol
+++ b/contracts/test/Governable.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity ^0.8.0;
+
+import { Governable } from '../utils/Governable.sol';
+
+contract GovernableTest is Governable {}

--- a/contracts/utils/Governable.sol
+++ b/contracts/utils/Governable.sol
@@ -82,8 +82,6 @@ abstract contract Governable is IGovernable, Initializable, ContextUpgradeable {
     /// @notice Initiates governance transfer to a new account (`newGovernancePending`).
     /// @param newGovernancePending the new governance address
     function initiateGovernanceTransfer(address newGovernancePending) external virtual onlyGovernance {
-        _ensureNonZero(newGovernancePending);
-
         emit GovernancePending(_governancePending, newGovernancePending);
         _governancePending = newGovernancePending;
     }
@@ -100,8 +98,6 @@ abstract contract Governable is IGovernable, Initializable, ContextUpgradeable {
     /// @notice Initiates teamMultisig transfer to a new account (`newTeamMultisigPending`).
     /// @param newTeamMultisigPending the new team multisig address
     function initiateTeamMultisigTransfer(address newTeamMultisigPending) external virtual onlyGovernance {
-        _ensureNonZero(newTeamMultisigPending);
-
         emit TeamMultisigPending(_teamMultisigPending, newTeamMultisigPending);
         _teamMultisigPending = newTeamMultisigPending;
     }
@@ -113,11 +109,5 @@ abstract contract Governable is IGovernable, Initializable, ContextUpgradeable {
         emit TeamMultisigTransferred(_teamMultisig, _teamMultisigPending);
         _teamMultisig = _teamMultisigPending;
         _teamMultisigPending = address(0);
-    }
-
-    /// @notice Ensures that the passed value is not zero address
-    /// @param value the value to check
-    function _ensureNonZero(address value) private pure {
-        if (value == address(0)) revert ZeroAddress();
     }
 }

--- a/contracts/utils/Governable.sol
+++ b/contracts/utils/Governable.sol
@@ -7,40 +7,37 @@ import { Initializable } from '@openzeppelin/contracts-upgradeable/proxy/utils/I
 
 import { IGovernable } from '../interfaces/IGovernable.sol';
 
-/**
- * This module is used through inheritance. It will make available the modifier
- * `onlyGovernance` and `onlyGovernanceOrTeamMultisig`, which can be applied to your functions
- * to restrict their use to the caller.
- */
+/// @title Governable module that exposes onlyGovernance and onlyGovernanceOrTeamMultisig modifiers
+/// @notice Copied and modified from @openzeppelin/contracts/access/Ownable.sol
 abstract contract Governable is IGovernable, Initializable, ContextUpgradeable {
     address private _governance;
     address private _teamMultisig;
+    address private _governancePending;
+    address private _teamMultisigPending;
 
     event GovernanceTransferred(address indexed previousGovernance, address indexed newGovernance);
     event TeamMultisigTransferred(address indexed previousTeamMultisig, address indexed newTeamMultisig);
+    event GovernancePending(address indexed previousGovernancePending, address indexed newGovernancePending);
+    event TeamMultisigPending(address indexed previousTeamMultisigPending, address indexed newTeamMultisigPending);
 
     error Unauthorised();
     error ZeroAddress();
 
-    /**
-     * @dev Initializes the contract setting the deployer as the initial governance and team multisig.
-     */
+    /// @notice Initializes the contract setting the deployer as the initial governance and team multisig.
     constructor() {
         __Governable_init();
     }
 
-    /**
-     * @dev Useful to proxy contracts for initializing
-     */
+    /// @notice Useful to proxy contracts for initializing
     function __Governable_init() internal initializer {
         __Context_init();
         address msgSender = _msgSender();
         __Governable_init(msgSender, msgSender);
     }
 
-    /**
-     * @dev Useful to proxy contracts for initializing with custom addresses
-     */
+    /// @notice Useful to proxy contracts for initializing with custom addresses
+    /// @param initialGovernance the initial governance address
+    /// @param initialTeamMultisig  the initial teamMultisig address
     function __Governable_init(address initialGovernance, address initialTeamMultisig) internal initializer {
         _governance = initialGovernance;
         emit GovernanceTransferred(address(0), initialGovernance);
@@ -49,53 +46,78 @@ abstract contract Governable is IGovernable, Initializable, ContextUpgradeable {
         emit TeamMultisigTransferred(address(0), initialTeamMultisig);
     }
 
-    /**
-     * @dev Returns the address of the current governance.
-     */
+    /// @notice Returns the address of the current governance.
+
     function governance() public view virtual returns (address) {
         return _governance;
     }
 
-    /**
-     * @dev Returns the address of the current team multisig.transferTeamMultisig
-     */
+    /// @notice Returns the address of the current governance.
+    function governancePending() public view virtual returns (address) {
+        return _governancePending;
+    }
+
+    /// @notice Returns the address of the current team multisig.transferTeamMultisig
     function teamMultisig() public view virtual returns (address) {
         return _teamMultisig;
     }
 
-    /**
-     * @dev Throws if called by any account other than the governance.
-     */
+    /// @notice Returns the address of the current team multisig.transferTeamMultisig
+    function teamMultisigPending() public view virtual returns (address) {
+        return _teamMultisigPending;
+    }
+
+    /// @notice Throws if called by any account other than the governance.
     modifier onlyGovernance() {
         if (governance() != _msgSender()) revert Unauthorised();
         _;
     }
 
-    /**
-     * @dev Throws if called by any account other than the governance or team multisig.
-     */
+    /// @notice Throws if called by any account other than the governance or team multisig.
     modifier onlyGovernanceOrTeamMultisig() {
         if (teamMultisig() != _msgSender() && governance() != _msgSender()) revert Unauthorised();
         _;
     }
 
-    /**
-     * @dev Transfers governance to a new account (`newGovernance`).
-     * Can only be called by the current governance.
-     */
-    function transferGovernance(address newGovernance) external virtual onlyGovernance {
-        if (newGovernance == address(0)) revert ZeroAddress();
-        emit GovernanceTransferred(_governance, newGovernance);
-        _governance = newGovernance;
+    /// @notice Initiates governance transfer to a new account (`newGovernancePending`).
+    /// @param newGovernancePending the new governance address
+    function initiateGovernanceTransfer(address newGovernancePending) external virtual onlyGovernance {
+        _ensureNonZero(newGovernancePending);
+
+        emit GovernancePending(_governancePending, newGovernancePending);
+        _governancePending = newGovernancePending;
     }
 
-    /**
-     * @dev Transfers teamMultisig to a new account (`newTeamMultisig`).
-     * Can only be called by the current teamMultisig or current governance.
-     */
-    function transferTeamMultisig(address newTeamMultisig) external virtual onlyGovernanceOrTeamMultisig {
-        if (newTeamMultisig == address(0)) revert ZeroAddress();
-        emit TeamMultisigTransferred(_teamMultisig, newTeamMultisig);
-        _teamMultisig = newTeamMultisig;
+    /// @notice Completes governance transfer, on being called by _governancePending.
+    function acceptGovernanceTransfer() external virtual {
+        if (_msgSender() != _governancePending) revert Unauthorised();
+
+        emit GovernanceTransferred(_governance, _governancePending);
+        _governance = _governancePending;
+        _governancePending = address(0);
+    }
+
+    /// @notice Initiates teamMultisig transfer to a new account (`newTeamMultisigPending`).
+    /// @param newTeamMultisigPending the new team multisig address
+    function initiateTeamMultisigTransfer(address newTeamMultisigPending) external virtual onlyGovernance {
+        _ensureNonZero(newTeamMultisigPending);
+
+        emit TeamMultisigPending(_teamMultisigPending, newTeamMultisigPending);
+        _teamMultisigPending = newTeamMultisigPending;
+    }
+
+    /// @notice Completes teamMultisig transfer, on being called by _teamMultisigPending.
+    function acceptTeamMultisigTransfer() external virtual {
+        if (_msgSender() != _teamMultisigPending) revert Unauthorised();
+
+        emit TeamMultisigTransferred(_teamMultisig, _teamMultisigPending);
+        _teamMultisig = _teamMultisigPending;
+        _teamMultisigPending = address(0);
+    }
+
+    /// @notice Ensures that the passed value is not zero address
+    /// @param value the value to check
+    function _ensureNonZero(address value) private pure {
+        if (value == address(0)) revert ZeroAddress();
     }
 }

--- a/test/units/Governable.spec.ts
+++ b/test/units/Governable.spec.ts
@@ -1,0 +1,96 @@
+import { expect } from 'chai';
+import hre, { ethers } from 'hardhat';
+import { GovernableTest } from '../../typechain-types';
+
+describe('Governable', () => {
+  const governableFixture = hre.deployments.createFixture(async hre => {
+    const factory = await hre.ethers.getContractFactory('GovernableTest');
+    return { governable: await factory.deploy() };
+  });
+
+  describe('#deploy', () => {
+    it('sets variables', async () => {
+      const { governable } = await governableFixture();
+      const [signer] = await hre.ethers.getSigners();
+      expect(await governable.governance()).to.eq(signer.address);
+      expect(await governable.teamMultisig()).to.eq(signer.address);
+    });
+  });
+
+  describe('#transfer', () => {
+    it('initiates governance transfer', async () => {
+      const { governable } = await governableFixture();
+      const [signer, otherSigner] = await hre.ethers.getSigners();
+      await governable.initiateGovernanceTransfer(otherSigner.address);
+
+      // sets pending variables
+      expect(await governable.governancePending()).to.eq(otherSigner.address);
+      expect(await governable.teamMultisigPending()).to.eq(ethers.constants.AddressZero);
+
+      // does not change ownership variables
+      expect(await governable.governance()).to.eq(signer.address);
+      expect(await governable.teamMultisig()).to.eq(signer.address);
+    });
+
+    it('initiates teamMultisig transfer', async () => {
+      const { governable } = await governableFixture();
+      const [signer, otherSigner] = await hre.ethers.getSigners();
+      await governable.initiateTeamMultisigTransfer(otherSigner.address);
+
+      // sets pending variables
+      expect(await governable.governancePending()).to.eq(ethers.constants.AddressZero);
+      expect(await governable.teamMultisigPending()).to.eq(otherSigner.address);
+
+      // does not change ownership variables
+      expect(await governable.governance()).to.eq(signer.address);
+      expect(await governable.teamMultisig()).to.eq(signer.address);
+    });
+
+    it('accepts governance transfer', async () => {
+      const { governable } = await governableFixture();
+      const [signer, otherSigner] = await hre.ethers.getSigners();
+
+      await governable.initiateGovernanceTransfer(otherSigner.address);
+
+      await expect(governable.acceptGovernanceTransfer()).to.be.revertedWith('Unauthorised()');
+
+      await governable.connect(otherSigner).acceptGovernanceTransfer();
+
+      // resets pending variable
+      expect(await governable.governancePending()).to.eq(ethers.constants.AddressZero);
+
+      // only changes governance address
+      expect(await governable.governance()).to.eq(otherSigner.address);
+      expect(await governable.teamMultisig()).to.eq(signer.address); // still the original signer
+    });
+
+    it('accepts teamMultisig transfer', async () => {
+      const { governable } = await governableFixture();
+      const [signer, otherSigner] = await hre.ethers.getSigners();
+
+      await governable.initiateTeamMultisigTransfer(otherSigner.address);
+
+      await expect(governable.acceptTeamMultisigTransfer()).to.be.revertedWith('Unauthorised()');
+
+      await governable.connect(otherSigner).acceptTeamMultisigTransfer();
+
+      // resets pending variable
+      expect(await governable.teamMultisigPending()).to.eq(ethers.constants.AddressZero);
+
+      // only changes teamMultisig address
+      expect(await governable.governance()).to.eq(signer.address); // still the original signer
+      expect(await governable.teamMultisig()).to.eq(otherSigner.address);
+    });
+
+    it('can change pending address to something again', async () => {
+      const { governable } = await governableFixture();
+      const [signer, signer2, signer3] = await hre.ethers.getSigners();
+
+      await governable.initiateGovernanceTransfer(signer2.address);
+      expect(await governable.governancePending()).to.eq(signer2.address);
+
+      await governable.initiateGovernanceTransfer(signer3.address);
+      expect(await governable.governancePending()).to.eq(signer3.address);
+    });
+  });
+});

--- a/test/units/Governable.spec.ts
+++ b/test/units/Governable.spec.ts
@@ -92,5 +92,16 @@ describe('Governable', () => {
       await governable.initiateGovernanceTransfer(signer3.address);
       expect(await governable.governancePending()).to.eq(signer3.address);
     });
+
+    it('can cancel transfer', async () => {
+      const { governable } = await governableFixture();
+      const [signer, signer2] = await hre.ethers.getSigners();
+
+      await governable.initiateGovernanceTransfer(signer2.address);
+      expect(await governable.governancePending()).to.eq(signer2.address);
+
+      await governable.initiateGovernanceTransfer(ethers.constants.AddressZero);
+      expect(await governable.governancePending()).to.eq(ethers.constants.AddressZero);
+    });
   });
 });

--- a/test/units/RageTradeFactory.spec.ts
+++ b/test/units/RageTradeFactory.spec.ts
@@ -24,10 +24,13 @@ describe('RageTradeFactory', () => {
       }
     });
 
-    // TODO add this test case
-    it.skip('initializes values', async () => {
-      const { vQuote, clearingHouse } = await setupClearingHouse({});
-      // expect(await clearingHouse.vQuote)
+    it('initializes values', async () => {
+      const { clearingHouse, rageTradeFactory, vQuote, settlementToken } = await setupClearingHouse({});
+      expect(await clearingHouse.rageTradeFactoryAddress()).to.eq(rageTradeFactory.address);
+
+      const info = await clearingHouse.getProtocolInfo();
+      expect(info.vQuote).to.eq(vQuote.address);
+      expect(info.settlementToken).to.eq(settlementToken.address);
     });
 
     it('governance and teamMultisig is deployer', async () => {


### PR DESCRIPTION
Changes the single operation transferGovernance method into a two operation initiate transfer and accept transfer methods. Since two variables governance and teamMultisig are present, this logic is applied to both.