### PR TITLE
QSP-16 Update version pragma

### DIFF
--- a/contracts/interfaces/IClearingHouse.sol
+++ b/contracts/interfaces/IClearingHouse.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.4;
 
 import { IGovernable } from './IGovernable.sol';
 

--- a/contracts/interfaces/IGovernable.sol
+++ b/contracts/interfaces/IGovernable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity >=0.5.0;
 
 interface IGovernable {
     function governance() external view returns (address);

--- a/contracts/interfaces/IInsuranceFund.sol
+++ b/contracts/interfaces/IInsuranceFund.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.4;
 
 import { IERC20 } from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 

--- a/contracts/interfaces/IOracle.sol
+++ b/contracts/interfaces/IOracle.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity >=0.5.0;
 
 interface IOracle {
     function getTwapPriceX128(uint32 twapDuration) external view returns (uint256 priceX128);

--- a/contracts/interfaces/IVPoolWrapper.sol
+++ b/contracts/interfaces/IVPoolWrapper.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.4;
 
 import { IUniswapV3Pool } from '@uniswap/v3-core-0.8-support/contracts/interfaces/IUniswapV3Pool.sol';
 

--- a/contracts/interfaces/IVQuote.sol
+++ b/contracts/interfaces/IVQuote.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.0;
 
 import { IERC20 } from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 

--- a/contracts/interfaces/IVToken.sol
+++ b/contracts/interfaces/IVToken.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.0;
 
 import { IERC20 } from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 

--- a/contracts/interfaces/clearinghouse/IClearingHouseActions.sol
+++ b/contracts/interfaces/clearinghouse/IClearingHouseActions.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.0;
 
 import { IClearingHouseStructures } from './IClearingHouseStructures.sol';
 

--- a/contracts/interfaces/clearinghouse/IClearingHouseCustomErrors.sol
+++ b/contracts/interfaces/clearinghouse/IClearingHouseCustomErrors.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.4;
 
 import { IERC20 } from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 

--- a/contracts/interfaces/clearinghouse/IClearingHouseEnums.sol
+++ b/contracts/interfaces/clearinghouse/IClearingHouseEnums.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.0;
 
 interface IClearingHouseEnums {
     enum LimitOrderType {

--- a/contracts/interfaces/clearinghouse/IClearingHouseEvents.sol
+++ b/contracts/interfaces/clearinghouse/IClearingHouseEvents.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.0;
 
 import { IERC20 } from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 

--- a/contracts/interfaces/clearinghouse/IClearingHouseOwnerActions.sol
+++ b/contracts/interfaces/clearinghouse/IClearingHouseOwnerActions.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.0;
 
 import { IERC20 } from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 

--- a/contracts/interfaces/clearinghouse/IClearingHouseStructures.sol
+++ b/contracts/interfaces/clearinghouse/IClearingHouseStructures.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.0;
 
 import { IERC20 } from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 import { IUniswapV3Pool } from '@uniswap/v3-core-0.8-support/contracts/interfaces/IUniswapV3Pool.sol';

--- a/contracts/interfaces/clearinghouse/IClearingHouseSystemActions.sol
+++ b/contracts/interfaces/clearinghouse/IClearingHouseSystemActions.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.0;
 
 import { IERC20 } from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 

--- a/contracts/interfaces/clearinghouse/IClearingHouseView.sol
+++ b/contracts/interfaces/clearinghouse/IClearingHouseView.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.0;
 
 import { IClearingHouseStructures } from './IClearingHouseStructures.sol';
 import { IExtsload } from '../IExtsload.sol';

--- a/contracts/lens/ClearingHouseLens.sol
+++ b/contracts/lens/ClearingHouseLens.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.4;
 
 import { IERC20 } from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 import { IUniswapV3Pool } from '@uniswap/v3-core-0.8-support/contracts/interfaces/IUniswapV3Pool.sol';

--- a/contracts/lens/SwapSimulator.sol
+++ b/contracts/lens/SwapSimulator.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.4;
 
 import { IUniswapV3Pool } from '@uniswap/v3-core-0.8-support/contracts/interfaces/IUniswapV3Pool.sol';
 import { TickMath } from '@uniswap/v3-core-0.8-support/contracts/libraries/TickMath.sol';

--- a/contracts/libraries/Account.sol
+++ b/contracts/libraries/Account.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.10;
+pragma solidity ^0.8.4;
 
 import { FixedPoint128 } from '@uniswap/v3-core-0.8-support/contracts/libraries/FixedPoint128.sol';
 import { FullMath } from '@uniswap/v3-core-0.8-support/contracts/libraries/FullMath.sol';

--- a/contracts/libraries/AddressHelper.sol
+++ b/contracts/libraries/AddressHelper.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.0;
 
 import { IERC20 } from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 

--- a/contracts/libraries/Bisection.sol
+++ b/contracts/libraries/Bisection.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.4;
 
 /// @title Bisection Method
 /// @notice https://en.wikipedia.org/wiki/Bisection_method

--- a/contracts/libraries/Block.sol
+++ b/contracts/libraries/Block.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.8.0;
 
 interface ArbSys {

--- a/contracts/libraries/CollateralDeposit.sol
+++ b/contracts/libraries/CollateralDeposit.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.4;
 
 import { FixedPoint128 } from '@uniswap/v3-core-0.8-support/contracts/libraries/FixedPoint128.sol';
 import { SafeCast } from '@uniswap/v3-core-0.8-support/contracts/libraries/SafeCast.sol';

--- a/contracts/libraries/FundingPayment.sol
+++ b/contracts/libraries/FundingPayment.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.4;
 
 import { FixedPoint128 } from '@uniswap/v3-core-0.8-support/contracts/libraries/FixedPoint128.sol';
 import { FullMath } from '@uniswap/v3-core-0.8-support/contracts/libraries/FullMath.sol';

--- a/contracts/libraries/GoodAddressDeployer.sol
+++ b/contracts/libraries/GoodAddressDeployer.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.0;
 
 import { Create2 } from '@openzeppelin/contracts/utils/Create2.sol';
 

--- a/contracts/libraries/LiquidityPosition.sol
+++ b/contracts/libraries/LiquidityPosition.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.4;
 
 import { SqrtPriceMath } from '@uniswap/v3-core-0.8-support/contracts/libraries/SqrtPriceMath.sol';
 import { TickMath } from '@uniswap/v3-core-0.8-support/contracts/libraries/TickMath.sol';

--- a/contracts/libraries/LiquidityPositionSet.sol
+++ b/contracts/libraries/LiquidityPositionSet.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.4;
 
 import { LiquidityPosition } from './LiquidityPosition.sol';
 import { Protocol } from './Protocol.sol';

--- a/contracts/libraries/PriceMath.sol
+++ b/contracts/libraries/PriceMath.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.4;
 
 import { FullMath } from '@uniswap/v3-core-0.8-support/contracts/libraries/FullMath.sol';
 import { FixedPoint96 } from '@uniswap/v3-core-0.8-support/contracts/libraries/FixedPoint96.sol';

--- a/contracts/libraries/Protocol.sol
+++ b/contracts/libraries/Protocol.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.4;
 
 import { IERC20 } from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 import { IUniswapV3Pool } from '@uniswap/v3-core-0.8-support/contracts/interfaces/IUniswapV3Pool.sol';

--- a/contracts/libraries/SafeCast.sol
+++ b/contracts/libraries/SafeCast.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.4;
 
 /// @title Safe cast functions
 library SafeCast {

--- a/contracts/libraries/SignedFullMath.sol
+++ b/contracts/libraries/SignedFullMath.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-pragma solidity >=0.8.0;
+pragma solidity ^0.8.0;
 
 import { FullMath } from '@uniswap/v3-core-0.8-support/contracts/libraries/FullMath.sol';
 import { SafeCast } from '@uniswap/v3-core-0.8-support/contracts/libraries/SafeCast.sol';

--- a/contracts/libraries/SignedMath.sol
+++ b/contracts/libraries/SignedMath.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.0;
 
 int256 constant ONE = 1;
 

--- a/contracts/libraries/SimulateSwap.sol
+++ b/contracts/libraries/SimulateSwap.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.4;
 
 import { FullMath } from '@uniswap/v3-core-0.8-support/contracts/libraries/FullMath.sol';
 import { FixedPoint128 } from '@uniswap/v3-core-0.8-support/contracts/libraries/FixedPoint128.sol';

--- a/contracts/libraries/SwapMath.sol
+++ b/contracts/libraries/SwapMath.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.4;
 
 import { SignedMath } from './SignedMath.sol';
 

--- a/contracts/libraries/TickBitmapExtended.sol
+++ b/contracts/libraries/TickBitmapExtended.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.0;
 
 import { BitMath } from '@uniswap/v3-core-0.8-support/contracts/libraries/BitMath.sol';
 

--- a/contracts/libraries/TickExtended.sol
+++ b/contracts/libraries/TickExtended.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.4;
 
 import { IUniswapV3Pool } from '@uniswap/v3-core-0.8-support/contracts/interfaces/IUniswapV3Pool.sol';
 

--- a/contracts/libraries/Uint32L8Array.sol
+++ b/contracts/libraries/Uint32L8Array.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.4;
 
 /// @title Uint32 length 8 array functions
 /// @dev Fits in one storage slot

--- a/contracts/libraries/Uint48.sol
+++ b/contracts/libraries/Uint48.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity >=0.5.0;
 
 /// @title Uint48 concating functions
 library Uint48Lib {

--- a/contracts/libraries/Uint48L5Array.sol
+++ b/contracts/libraries/Uint48L5Array.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.4;
 
 /// @title Uint48 length 5 array functions
 /// @dev Fits in one storage slot

--- a/contracts/libraries/UniswapV3PoolHelper.sol
+++ b/contracts/libraries/UniswapV3PoolHelper.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.4;
 
 import { TickMath } from '@uniswap/v3-core-0.8-support/contracts/libraries/TickMath.sol';
 

--- a/contracts/libraries/VTokenPosition.sol
+++ b/contracts/libraries/VTokenPosition.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.4;
 
 import { FullMath } from '@uniswap/v3-core-0.8-support/contracts/libraries/FullMath.sol';
 import { FixedPoint128 } from '@uniswap/v3-core-0.8-support/contracts/libraries/FixedPoint128.sol';

--- a/contracts/libraries/VTokenPositionSet.sol
+++ b/contracts/libraries/VTokenPositionSet.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.4;
 
 import { FixedPoint128 } from '@uniswap/v3-core-0.8-support/contracts/libraries/FixedPoint128.sol';
 import { SafeCast } from '@uniswap/v3-core-0.8-support/contracts/libraries/SafeCast.sol';

--- a/contracts/libraries/WordHelper.sol
+++ b/contracts/libraries/WordHelper.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity >=0.5.0;
 
 import { IClearingHouseStructures } from '../interfaces/clearinghouse/IClearingHouseStructures.sol';
 

--- a/contracts/oracles/ChainlinkOracle.sol
+++ b/contracts/oracles/ChainlinkOracle.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.4;
 
 import { Initializable } from '@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol';
 import { AggregatorV3Interface } from '@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol';

--- a/contracts/oracles/SettlementTokenOracle.sol
+++ b/contracts/oracles/SettlementTokenOracle.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity >=0.5.0;
 
 import { IOracle } from '../interfaces/IOracle.sol';
 

--- a/contracts/protocol/RageTradeFactory.sol
+++ b/contracts/protocol/RageTradeFactory.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-pragma solidity ^0.8.9;
+pragma solidity =0.8.14;
 
 import { IERC20Metadata } from '@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol';
 import { ProxyAdmin } from '@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol';

--- a/contracts/protocol/clearinghouse/ClearingHouse.sol
+++ b/contracts/protocol/clearinghouse/ClearingHouse.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.9;
+pragma solidity =0.8.14;
 
 import { IERC20 } from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 import { Initializable } from '@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol';

--- a/contracts/protocol/clearinghouse/ClearingHouseDeployer.sol
+++ b/contracts/protocol/clearinghouse/ClearingHouseDeployer.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-pragma solidity ^0.8.9;
+pragma solidity =0.8.14;
 
 import { TransparentUpgradeableProxy } from '@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol';
 import { IERC20 } from '@openzeppelin/contracts/token/ERC20/IERC20.sol';

--- a/contracts/protocol/clearinghouse/ClearingHouseStorage.sol
+++ b/contracts/protocol/clearinghouse/ClearingHouseStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.9;
+pragma solidity =0.8.14;
 
 import { Account } from '../../libraries/Account.sol';
 import { BatchedLoop } from '../../libraries/BatchedLoop.sol';

--- a/contracts/protocol/clearinghouse/ClearingHouseView.sol
+++ b/contracts/protocol/clearinghouse/ClearingHouseView.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.9;
+pragma solidity =0.8.14;
 
 import { IClearingHouse } from '../../interfaces/IClearingHouse.sol';
 import { IClearingHouseView } from '../../interfaces/clearinghouse/IClearingHouseView.sol';

--- a/contracts/protocol/insurancefund/InsuranceFund.sol
+++ b/contracts/protocol/insurancefund/InsuranceFund.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-pragma solidity ^0.8.9;
+pragma solidity =0.8.14;
 
 import { ERC20Upgradeable } from '@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol';
 import { Initializable } from '@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol';

--- a/contracts/protocol/insurancefund/InsuranceFundDeployer.sol
+++ b/contracts/protocol/insurancefund/InsuranceFundDeployer.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-pragma solidity ^0.8.9;
+pragma solidity =0.8.14;
 
 import { IERC20 } from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 import { TransparentUpgradeableProxy } from '@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol';

--- a/contracts/protocol/tokens/VQuote.sol
+++ b/contracts/protocol/tokens/VQuote.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-pragma solidity ^0.8.9;
+pragma solidity =0.8.14;
 
 import { ERC20 } from '@openzeppelin/contracts/token/ERC20/ERC20.sol';
 import { Ownable } from '@openzeppelin/contracts/access/Ownable.sol';

--- a/contracts/protocol/tokens/VQuoteDeployer.sol
+++ b/contracts/protocol/tokens/VQuoteDeployer.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-pragma solidity ^0.8.9;
+pragma solidity =0.8.14;
 
 import { IVQuote } from '../../interfaces/IVQuote.sol';
 

--- a/contracts/protocol/tokens/VToken.sol
+++ b/contracts/protocol/tokens/VToken.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity =0.8.14;
 
 import { ERC20 } from '@openzeppelin/contracts/token/ERC20/ERC20.sol';
 import { Ownable } from '@openzeppelin/contracts/access/Ownable.sol';

--- a/contracts/protocol/tokens/VTokenDeployer.sol
+++ b/contracts/protocol/tokens/VTokenDeployer.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity =0.8.14;
 
 import { Create2 } from '@openzeppelin/contracts/utils/Create2.sol';
 

--- a/contracts/protocol/wrapper/VPoolWrapper.sol
+++ b/contracts/protocol/wrapper/VPoolWrapper.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.9;
+pragma solidity =0.8.14;
 
 import { Initializable } from '@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol';
 

--- a/contracts/protocol/wrapper/VPoolWrapperDeployer.sol
+++ b/contracts/protocol/wrapper/VPoolWrapperDeployer.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-pragma solidity ^0.8.9;
+pragma solidity =0.8.14;
 
 import { TransparentUpgradeableProxy } from '@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol';
 

--- a/contracts/utils/Extsload.sol
+++ b/contracts/utils/Extsload.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity >=0.5.0;
 
 import { IExtsload } from '../interfaces/IExtsload.sol';
 

--- a/contracts/utils/Governable.sol
+++ b/contracts/utils/Governable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.4;
 
 import { ContextUpgradeable } from '@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol';
 import { Initializable } from '@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol';

--- a/contracts/utils/ProxyAdminDeployer.sol
+++ b/contracts/utils/ProxyAdminDeployer.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity ^0.8.0;
 
 import { ProxyAdmin } from '@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol';
 

--- a/contracts/utils/constants.sol
+++ b/contracts/utils/constants.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.9;
+pragma solidity >=0.5.0;
 
 // Uniswap V3 Factory address is same across different networks
 address constant UNISWAP_V3_FACTORY_ADDRESS = 0x1F98431c8aD98523631AE4a59f267346ea31F984;

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -130,9 +130,10 @@ export default {
       {
         version: '0.8.14',
         settings: {
+          viaIR: true,
           optimizer: {
             enabled: true,
-            runs: 833,
+            runs: 4999,
           },
           outputSelection: {
             '*': {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -128,7 +128,7 @@ export default {
   solidity: {
     compilers: [
       {
-        version: '0.8.13',
+        version: '0.8.14',
         settings: {
           optimizer: {
             enabled: true,


### PR DESCRIPTION
- For files inside `protocol` directory, pragma version directive locks the solidity version to `0.8.14`.
- For other files, the version directive is updated for other files to maximise compatibility other repositories that might use different solidity versions.